### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ function unflatten (obj, opts) {
   var re = new RegExp(separator, 'g')
   var newObj = {}
   for (let path in obj) {
+    path = path.replace('__proto__'+separator, '').replace('constructor'+separator, '').replace('prototype'+separator,'');
     if (objectMode) {
       _setWith(newObj, dotSep ? path : path.replace(re, '.'), obj[path], Object)
     } else {


### PR DESCRIPTION
`unflatten` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior using a `__proto__` payload, which may result in Information Disclosure/DoS/RCE.

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes, by sanitizing path before sending to loadash

### 🐛 Proof of Concept (PoC) *

1. Install the package(npm i unflatten), run the below code:

```
var unflatten = require("unflatten")
unflatten({'__proto__.polluted': true});
console.log(polluted); 
```

Outputs true.

![unflattenPOC](https://user-images.githubusercontent.com/7505980/95335707-65366380-08b8-11eb-9c5c-e4501b361dd2.png)


### 🔥 Proof of Fix (PoF) *

After fix execution returns: polluted is not defined



### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected